### PR TITLE
Implement bot shutdown command and on_disconnect event handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,11 @@ async def ban(ctx, member: disnake.Member, *, reason="Rules broker"):
     await member.ban(reason = reason)
     await ctx.message.delete()
 
+@bot.command
+async def shutdown (ctx: commands.Context):
+    await ctx.send("Disconnected")
+    await bot.close()
+
 @bot.event
 async def on_command_error(ctx, error):
     print(error)

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ async def on_ready():
         color = 0xffe32e
     )
     await channel.send(embed = embed)
+    await bot.change_presence(activity=disnake.Activity(type=disnake.ActivityType.watching, name="for commands"))
 
 # Create variables for entering ids for channels of functions
 # And paste it to bot.get_channel()
@@ -53,24 +54,19 @@ async def on_message(message):
                 await message.delete()
                 await message.channel.send(f"{message.author.mention } such repliks is forbidden, Glory to Ukraine!")
 
-@bot.slash_command(brief="If someone will break some rules or will try to crash server, he will get kick")
+@bot.slash_command(brief="If someone will break some rules or will try to crash server, he will get kick", usage="/kick <@user> reason=None")
 @commands.has_permissions(kick_members = True, administrator = True)
 async def kick(ctx, member: disnake.Member, *, reason="Rules broker"):
     await ctx.send(f"Moderator {ctx.author.mention} kicked user {member.mention}", delete_after=300)
     await member.kick(reason = reason)
     await ctx.message.delete()
 
-@bot.slash_command(aliases="БАН НАХУЙ", brief="If someone will break some rules or will try to crash server, he will get ban" )
+@bot.slash_command(aliases="БАН НАХУЙ", brief="If someone will break some rules or will try to crash server, he will get ban", usage="/ban <@user> reason=None")
 @commands.has_permissions(ban_members = True, administrator = True)
 async def ban(ctx, member: disnake.Member, *, reason="Rules broker"):
     await ctx.send(f"Moderator {ctx.author.mention} baned user {member.mention}", delete_after=300)
     await member.ban(reason = reason)
     await ctx.message.delete()
-
-@bot.command
-async def shutdown (ctx: commands.Context):
-    await ctx.send("Disconnected")
-    await bot.close()
 
 @bot.event
 async def on_command_error(ctx, error):
@@ -83,5 +79,18 @@ async def on_command_error(ctx, error):
             description=f"Correct usage of command: `{ctx.prefix}{ctx.command.name}`({ctx.command.brief})\nExample: {ctx.prefix}{ctx.command.usage}"
 
         ))
+
+@bot.event
+async def on_disconnect():
+    print("Bot disconnected")
+
+@bot.event
+async def on_shutdown():
+    print("Bot shutting down...")
+
+@bot.slash_command(name='shutdown', description='Выключает бота')
+async def shutdown(ctx: disnake.ApplicationCommandInteraction):
+    await ctx.response.send_message('Выключаюсь...')
+    await bot.close()
 
 bot.run(data["token"])


### PR DESCRIPTION
- Added a shutdown command that stops the bot and sends a message to confirm the action

- Added an on_disconnect event handler that logs when the bot is disconnected from Discord